### PR TITLE
Switch configurable RPi GPIO when authenticated

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,12 +1,13 @@
 #!/usr/bin/python3.8
 
 import nfc
-import ndef
-from threading import Thread
 from keystore import KeyStore
 import sys
 import logging
 import argparse
+from gpiozero import OutputDevice
+from sched import scheduler as Scheduler
+from time import time, sleep
 
 LOG_LEVEL = logging.DEBUG
 
@@ -15,11 +16,16 @@ logger = logging.getLogger(__name__)
 parser = argparse.ArgumentParser(description='Authenticate via nfc.')
 parser.add_argument('--add-key', action='store_true')
 parser.add_argument('--daemon', action='store_true')
+parser.add_argument('--pin')
 args = parser.parse_args()
 print(args)
 
+pin = OutputDevice(args.pin)
+scheduler = Scheduler(time, sleep)
+currentEvent = None
 
 def work_on_tag(tag):
+    global currentEvent
     logger.debug('Tag found: ' + str(tag))
 
     keystore = KeyStore()
@@ -29,7 +35,10 @@ def work_on_tag(tag):
     key = keystore.get_key_from_db(tag.identifier)
     print(tag.__class__.__name__)
 
-    if key is None and args.add_key and tag.__class__.__name__ == 'NTAG215':
+    if key is None or tag.__class__.__name__ != 'NTAG215':
+        return
+
+    if args.add_key:
         key = keystore.add_new_key(tag.identifier)
         secret = key[0]
         key = key[1]
@@ -39,9 +48,15 @@ def work_on_tag(tag):
         tag.write(9, secret[12:16])
         tag.protect(password=key.get_access_key(), read_protect=True, protect_from=4)
     else:
-        if key is not None:
-            print(tag.authenticate(key.access_key))
-            print(key.validate(tag.read(6)))
+        if tag.authenticate(key.access_key) and key.validate(tag.read(6)):
+            if pin.is_active():
+                pin.off()
+                if currentEvent:
+                    scheduler.cancel(currentEvent)
+            else:
+                pin.on()
+                currentEvent = scheduler.enter(7200, 1, pin.off)
+
 
 
 clf = nfc.ContactlessFrontend('usb')


### PR DESCRIPTION
If a valid NFC tag is detected, the configured GPIO is toggled.
If the GPIO is toggled from low to high, a scheduler is started to set the pin low after 2 hours.
If the GPIO is toggled from high to low, the scheduler is stopped.